### PR TITLE
test: update

### DIFF
--- a/results/cmproxy.json
+++ b/results/cmproxy.json
@@ -453,10 +453,7 @@
   "headers-store-Cache-Control": true,
   "headers-store-Clear-Site-Data": true,
   "headers-store-Connection": true,
-  "headers-store-Content-Encoding": [
-    "Assertion",
-    "Response 2 header Content-Encoding is \"null\", not \"apetixmbqfujync\""
-  ],
+  "headers-store-Content-Encoding": true,
   "headers-store-Content-Foo": true,
   "headers-store-Content-Length": true,
   "headers-store-Content-Location": true,


### PR DESCRIPTION
Result changed after cmproxy's dependencies were updated.
Now `headers-store-Content-Encoding` matches results from other sources.